### PR TITLE
Fix Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,12 @@ gemfile:
   - gemfiles/rails4.2.gemfile
   - gemfiles/rails5.0.gemfile
 
-sudo: false
+sudo: required
 
 bundler_args: --no-deployment
+
+before_script:
+  - sudo cp /usr/share/doc/mysql-server-5.6/examples/my-default.cnf /usr/share/mysql/my-default.cnf
 
 script: bundle exec rake test
 

--- a/ar_mysql_flexmaster.gemspec
+++ b/ar_mysql_flexmaster.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("mocha", "~> 1.1.0")
   gem.add_development_dependency("bump")
   gem.add_development_dependency("pry")
-  gem.add_development_dependency("mysql_isolated_server", "~> 0.5")
+  gem.add_development_dependency("isolated_server")
 end

--- a/gemfiles/rails3.2.gemfile.lock
+++ b/gemfiles/rails3.2.gemfile.lock
@@ -43,6 +43,7 @@ GEM
     erubis (2.7.0)
     hike (1.2.3)
     i18n (0.8.6)
+    isolated_server (0.4.12)
     journey (1.0.4)
     json (1.8.6)
     mail (2.5.5)
@@ -56,7 +57,6 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.12.1)
     mysql2 (0.3.21)
-    mysql_isolated_server (0.5.4)
     polyglot (0.3.5)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -107,14 +107,14 @@ PLATFORMS
 DEPENDENCIES
   ar_mysql_flexmaster!
   bump
+  isolated_server
   minitest
   mocha (~> 1.1.0)
   mysql2 (~> 0.3.0)
-  mysql_isolated_server (~> 0.5)
   pry
   rails (~> 3.2.0)
   rake
   wwtd
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -53,6 +53,7 @@ GEM
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     i18n (0.8.6)
+    isolated_server (0.4.12)
     json (1.8.6)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -68,7 +69,6 @@ GEM
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     mysql2 (0.4.9)
-    mysql_isolated_server (0.5.4)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
     pry (0.10.4)
@@ -123,13 +123,13 @@ PLATFORMS
 DEPENDENCIES
   ar_mysql_flexmaster!
   bump
+  isolated_server
   minitest
   mocha (~> 1.1.0)
-  mysql_isolated_server (~> 0.5)
   pry
   rails (~> 4.2.0, < 4.2.8)
   rake
   wwtd
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -55,6 +55,7 @@ GEM
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     i18n (0.8.6)
+    isolated_server (0.4.12)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
@@ -69,7 +70,6 @@ GEM
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     mysql2 (0.4.9)
-    mysql_isolated_server (0.5.4)
     nio4r (1.2.1)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
@@ -127,13 +127,13 @@ PLATFORMS
 DEPENDENCIES
   ar_mysql_flexmaster!
   bump
+  isolated_server
   minitest
   mocha (~> 1.1.0)
-  mysql_isolated_server (~> 0.5)
   pry
   rails (~> 5.0.0, < 5.0.1)
   rake
   wwtd
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/test/boot_mysql_env.rb
+++ b/test/boot_mysql_env.rb
@@ -1,25 +1,25 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "mysql_isolated_server"
+require "isolated_server"
 
 threads = []
 threads << Thread.new do
-  $mysql_master = MysqlIsolatedServer.new(allow_output: false)
+  $mysql_master = IsolatedServer::Mysql.new(allow_output: false)
   $mysql_master.boot!
 
   puts "mysql master booted on port #{$mysql_master.port} -- access with mysql -uroot -h127.0.0.1 --port=#{$mysql_master.port} mysql"
 end
 
 threads << Thread.new do
-  $mysql_slave = MysqlIsolatedServer.new
+  $mysql_slave = IsolatedServer::Mysql.new
   $mysql_slave.boot!
 
   puts "mysql slave booted on port #{$mysql_slave.port} -- access with mysql -uroot -h127.0.0.1 --port=#{$mysql_slave.port} mysql"
 end
 
 threads << Thread.new do
-  $mysql_slave_2 = MysqlIsolatedServer.new
+  $mysql_slave_2 = IsolatedServer::Mysql.new
   $mysql_slave_2.boot!
 
   puts "mysql chained slave booted on port #{$mysql_slave_2.port} -- access with mysql -uroot -h127.0.0.1 --port=#{$mysql_slave_2.port} mysql"

--- a/test/boot_slave
+++ b/test/boot_slave
@@ -1,16 +1,16 @@
-require_relative 'mysql_isolated_server'
+require_relative 'isolated_server'
 
 # yeah, not technically isolated
-master = MysqlIsolatedServer.new(port: 3306)
+master = IsolatedServer::Mysql.new(port: 3306)
 
-slave = MysqlIsolatedServer.new(data_path: "/Users/ben/.zendesk/var/mysql", allow_output: true, params: "--relay-log=footwa --skip-slave-start", port: 41756)
+slave = IsolatedServer::Mysql.new(data_path: "/Users/ben/.zendesk/var/mysql", allow_output: true, params: "--relay-log=footwa --skip-slave-start", port: 41756)
 slave.boot! 
 puts "mysql slave booted on port #{slave.port} -- access with mysql -uroot -h127.0.0.1 --port=#{slave.port} mysql"
 slave.connection.query("set global server_id=123")
 slave.make_slave_of(master) 
 slave.set_rw(false)
 
-uid_server = MysqlIsolatedServer.new(data_path: "/Users/ben/.zendesk/var/mysql", allow_output: true, params: "--skip-slave-start", port: 41757)
+uid_server = IsolatedServer::Mysql.new(data_path: "/Users/ben/.zendesk/var/mysql", allow_output: true, params: "--skip-slave-start", port: 41757)
 uid_server.boot! 
 puts "mysql uid server booted on port #{uid_server.port} -- access with mysql -uroot -h127.0.0.1 --port=#{uid_server.port} mysql"
 sleep


### PR DESCRIPTION
The Travis-CI build for this gem has been broken for some time due to changes in the Travis-CI build infrastructure.

Specifically, the `my-default.cnf` file which `mysql_install_db` uses as a template for `my.cnf` is not in the location that `mysql_install_db` expects.

We can copy it to the right location using a `before_script`, but that requires `sudo`, so we needed `sudo: required` on the whole Travis build.

Also: The http://github.com/osheroff/mysql_isolated_server gem has fallen into disrepair. The fork of it http://github.com/zendesk/isolated_server is in slightly better shape, so switched to use that.