### PR TITLE
Add bundler/gem_tasks to Rakefile, bundler as a development dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require 'bundler/gem_tasks'
 require 'rake/testtask'
 
 require 'bump/tasks'

--- a/ar_mysql_flexmaster.gemspec
+++ b/ar_mysql_flexmaster.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("mysql2")
   gem.add_runtime_dependency("activerecord")
   gem.add_runtime_dependency("activesupport")
+  gem.add_development_dependency("bundler")
   gem.add_development_dependency("rake")
   gem.add_development_dependency("wwtd")
   gem.add_development_dependency("minitest")


### PR DESCRIPTION
Got my last change pushed with TIL `gem push`, but I've always used `bundle exec rake release`

@gabetax @bquorning 