### PR TITLE
Faster test runs on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.2.6
-  - 2.3.3
-  - 2.4.1
+  - 2.2
+  - 2.3
+  - 2.4
 
 gemfile:
   - gemfiles/rails3.2.gemfile
@@ -22,5 +22,5 @@ script: bundle exec rake test
 
 matrix:
   exclude:
-    - rvm: 2.4.1
+    - rvm: 2.4
       gemfile: gemfiles/rails3.2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 cache: bundler
+branches:
+  only: master
 
 rvm:
   - 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 
 rvm:
   - 2.2.6

--- a/ar_mysql_flexmaster.gemspec
+++ b/ar_mysql_flexmaster.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("rake")
   gem.add_development_dependency("wwtd")
   gem.add_development_dependency("minitest")
+  gem.add_development_dependency("minitest-reporters")
   gem.add_development_dependency("mocha", "~> 1.1.0")
   gem.add_development_dependency("bump")
   gem.add_development_dependency("pry")

--- a/gemfiles/rails3.2.gemfile.lock
+++ b/gemfiles/rails3.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ar_mysql_flexmaster (1.0.2)
+    ar_mysql_flexmaster (1.0.3)
       activerecord
       activesupport
       mysql2
@@ -107,6 +107,7 @@ PLATFORMS
 DEPENDENCIES
   ar_mysql_flexmaster!
   bump
+  bundler
   isolated_server
   minitest
   mocha (~> 1.1.0)
@@ -117,4 +118,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/gemfiles/rails3.2.gemfile.lock
+++ b/gemfiles/rails3.2.gemfile.lock
@@ -36,6 +36,7 @@ GEM
     activesupport (3.2.22.5)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
+    ansi (1.5.0)
     arel (3.0.3)
     builder (3.0.4)
     bump (0.5.4)
@@ -53,6 +54,11 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     minitest (5.10.3)
+    minitest-reporters (1.1.18)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.12.1)
@@ -87,6 +93,7 @@ GEM
     rake (12.0.0)
     rdoc (3.12.2)
       json (~> 1.4)
+    ruby-progressbar (1.9.0)
     slop (3.6.0)
     sprockets (2.2.3)
       hike (~> 1.2)
@@ -110,6 +117,7 @@ DEPENDENCIES
   bundler
   isolated_server
   minitest
+  minitest-reporters
   mocha (~> 1.1.0)
   mysql2 (~> 0.3.0)
   pry

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ar_mysql_flexmaster (1.0.2)
+    ar_mysql_flexmaster (1.0.3)
       activerecord
       activesupport
       mysql2
@@ -123,6 +123,7 @@ PLATFORMS
 DEPENDENCIES
   ar_mysql_flexmaster!
   bump
+  bundler
   isolated_server
   minitest
   mocha (~> 1.1.0)
@@ -132,4 +133,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -44,6 +44,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    ansi (1.5.0)
     arel (6.0.4)
     builder (3.2.3)
     bump (0.5.4)
@@ -66,6 +67,11 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.2.0)
     minitest (5.10.3)
+    minitest-reporters (1.1.18)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     mysql2 (0.4.9)
@@ -103,6 +109,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
+    ruby-progressbar (1.9.0)
     slop (3.6.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
@@ -126,6 +133,7 @@ DEPENDENCIES
   bundler
   isolated_server
   minitest
+  minitest-reporters
   mocha (~> 1.1.0)
   pry
   rails (~> 4.2.0, < 4.2.8)

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ar_mysql_flexmaster (1.0.2)
+    ar_mysql_flexmaster (1.0.3)
       activerecord
       activesupport
       mysql2
@@ -127,6 +127,7 @@ PLATFORMS
 DEPENDENCIES
   ar_mysql_flexmaster!
   bump
+  bundler
   isolated_server
   minitest
   mocha (~> 1.1.0)
@@ -136,4 +137,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -46,6 +46,7 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    ansi (1.5.0)
     arel (7.1.4)
     builder (3.2.3)
     bump (0.5.4)
@@ -67,6 +68,11 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.2.0)
     minitest (5.10.3)
+    minitest-reporters (1.1.18)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     mysql2 (0.4.9)
@@ -104,6 +110,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
+    ruby-progressbar (1.9.0)
     slop (3.6.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
@@ -130,6 +137,7 @@ DEPENDENCIES
   bundler
   isolated_server
   minitest
+  minitest-reporters
   mocha (~> 1.1.0)
   pry
   rails (~> 5.0.0, < 5.0.1)

--- a/test/ar_flexmaster_test.rb
+++ b/test/ar_flexmaster_test.rb
@@ -1,14 +1,18 @@
 # frozen_string_literal: true
 require 'bundler/setup'
 require 'ar_mysql_flexmaster'
+require 'active_support'
 require 'active_record'
 require 'minitest/autorun'
+require "minitest/reporters"
 require 'mocha/mini_test'
 require 'logger'
 
 if !defined?(Minitest::Test)
   Minitest::Test = MiniTest::Unit::TestCase
 end
+
+Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new(color: true))
 
 require_relative 'boot_mysql_env'
 

--- a/test/ar_flexmaster_test.rb
+++ b/test/ar_flexmaster_test.rb
@@ -222,7 +222,7 @@ class TestArFlexmaster < Minitest::Test
       User.create!
     end
 
-    assert_equal nil, User.connection.instance_variable_get("@connection")
+    assert_nil User.connection.instance_variable_get("@connection")
 
     # this proxies to @connection and has been the cause of some crashes
     assert User.connection.quote("foo")


### PR DESCRIPTION
By letting Travis choose pre-installed Ruby versions, and cache the bundled gems, we can save > 60 seconds on every test run.